### PR TITLE
Added pose estimate param defaults.

### DIFF
--- a/sense_aruco/src/sense_aruco/aruco_estimator.py
+++ b/sense_aruco/src/sense_aruco/aruco_estimator.py
@@ -16,6 +16,12 @@ class ArucoMarkerEstimator:
         self.__marker_side_len = None
         self.__family_name = None
 
+        # Ensure we set the default estimation for now.
+        self.__estimate_parameters = cv2.aruco.EstimateParameters().create()
+        self.__estimate_parameters.pattern = cv2.aruco.CCW_center
+        self.__estimate_parameters.useExtrinsicGuess = False
+        self.__estimate_parameters.solvePnPMethod = cv2.SOLVEPNP_ITERATIVE
+
         if paramfilepath is not None:
             self.load_camera_params(paramfilepath)
 
@@ -116,7 +122,8 @@ class ArucoMarkerEstimator:
         rvecs, tvecs, objpts = cv2.aruco.estimatePoseSingleMarkers(
             corners=detections['corners'],
             markerLength=self.__marker_side_len,
-            cameraMatrix=self.__calib_mat, distCoeffs=self.__calib_dst)
+            cameraMatrix=self.__calib_mat, distCoeffs=self.__calib_dst,
+            estimateParameters=self.__estimate_parameters)
 
         # Sanity check.
         if len(detections) != len(rvecs):


### PR DESCRIPTION
The initial goal of this branch was to ensure that the estimator outputs the pose of the marker relative to the camera. The [ArUco tutorial](https://docs.opencv.org/4.x/d5/dae/tutorial_aruco_detection.html) seems to say that the function `cv::aruco::estimatePoseSingleMarkers` estimates the pose of the camera relative to the marker. However, the [documentation for the function](https://docs.opencv.org/4.x/d9/d6a/group__aruco.html#ga56878c4f94362c9420f20b78de0def9b) says that the function estimates the pose of the marker relative to the camera. Personal experimentation verifies that the function estimates the pose of the marker relative to the camera.

To ensure a specific default behavior, I added estimation parameters to `estimatePoseSingleMarkers` function in `ArucoMarkerEstimator`.